### PR TITLE
feat: add env 

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,67 @@
+/**
+ * Configuration interface for environment runtime information.
+ */
+export interface EnvRuntimeConfig {
+  /**
+   * Indicates whether the current environment supports TTY capabilities
+   */
+  isTTY: boolean;
+
+  /** Array of command line arguments passed to the process */
+  argv: string[];
+
+  /** The operating system platform (e.g., 'win32', 'darwin', 'linux') */
+  platform: string;
+
+  /** Environment variables available to the process */
+  env: Record<string, string | undefined>;
+
+  /** The JavaScript runtime environment being used */
+  runtime: "deno" | "node" | "bun";
+}
+
+/**
+ * Returns runtime configuration details for the current JavaScript environment.
+ *
+ * @param {globalThis} mockGlobal - Optional global object to use instead of the default globalThis.
+ *
+ * @returns {EnvRuntimeConfig} The runtime configuration object
+ *
+ * @example
+ * ```ts
+ * const config = getRuntimeConfig();
+ * console.log(config.runtime); // 'node', 'deno', or 'bun'
+ * console.log(config.env.NODE_ENV); // Access environment variables
+ *
+ * // For mock testing
+ * const mockGlobal = { process: { env: { NODE_ENV: 'development' } } };
+ * const config = getRuntimeConfig(mockGlobal);
+ * ```
+ */
+export function getRuntimeConfig(mockGlobal?: typeof globalThis): EnvRuntimeConfig {
+  const _global = mockGlobal || globalThis;
+  const Deno = (_global as any).Deno;
+  const Bun = (_global as any).Bun;
+  const isDeno = Deno != null;
+  const isBun = Bun != null;
+
+  // eslint-disable-next-line node/prefer-global/process
+  const proc = _global.process || Deno || {};
+
+  let env: Record<string, string | undefined> = proc.env || {};
+  if (isDeno) {
+    try {
+      env = Deno.env.toObject();
+    } catch {
+      env = {};
+    }
+  }
+
+  return {
+    env,
+    isTTY: isDeno ? Deno.isatty(1) : !!(proc.stdout?.isTTY),
+    platform: isDeno ? Deno.build.os : proc.platform,
+    argv: proc.argv || (proc as any).args || [],
+    runtime: isDeno ? "deno" : isBun ? "bun" : "node",
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export {
   getSupportedLevel,
 } from "./supports";
 
+export { getRuntimeConfig, type EnvRuntimeConfig } from "./env";
+
 export { isUnicodeSupported } from "./unicode";
 
 export { getWindowSize } from "./window-size";

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "vitest";
+import { getRuntimeConfig } from "../src/env";
+
+it("should return correct config for Node.js environment", () => {
+  const mockGlobal = {
+    process: {
+      env: { NODE_ENV: "test" },
+      stdout: { isTTY: true },
+      platform: "linux",
+      argv: ["node", "script.js"],
+    },
+  } as any;
+
+  const config = getRuntimeConfig(mockGlobal);
+
+  expect(config.env.NODE_ENV).toBe("test");
+  expect(config.isTTY).toBe(true);
+  expect(config.platform).toBe("linux");
+  expect(config.argv).toEqual(["node", "script.js"]);
+  expect(config.runtime).toBe("node");
+});
+
+it("should return correct config for Deno environment", () => {
+  const mockGlobal = {
+    Deno: {
+      env: {
+        toObject: () => ({ DENO_ENV: "test" }),
+      },
+      isatty: () => true,
+      build: { os: "darwin" },
+      args: ["deno", "script.ts"],
+    },
+  } as any;
+
+  const config = getRuntimeConfig(mockGlobal);
+
+  expect(config.env.DENO_ENV).toBe("test");
+  expect(config.isTTY).toBe(true);
+  expect(config.platform).toBe("darwin");
+  expect(config.argv).toEqual(["deno", "script.ts"]);
+  expect(config.runtime).toBe("deno");
+});
+
+it("should return correct config for Bun environment", () => {
+  const mockGlobal = {
+    Bun: {},
+    process: {
+      env: { BUN_ENV: "test" },
+      stdout: { isTTY: false },
+      platform: "win32",
+      argv: ["bun", "script.js"],
+    },
+  } as any;
+
+  const config = getRuntimeConfig(mockGlobal);
+
+  expect(config.env.BUN_ENV).toBe("test");
+  expect(config.isTTY).toBe(false);
+  expect(config.platform).toBe("win32");
+  expect(config.argv).toEqual(["bun", "script.js"]);
+  expect(config.runtime).toBe("bun");
+});
+
+it("should handle missing environment variables gracefully", () => {
+  const mockGlobal = {
+    process: {
+      env: undefined,
+      stdout: { isTTY: false },
+      platform: "linux",
+      argv: ["node", "script.js"],
+    },
+  } as any;
+
+  const config = getRuntimeConfig(mockGlobal);
+
+  expect(config.env).toEqual({});
+  expect(config.isTTY).toBe(false);
+  expect(config.platform).toBe("linux");
+  expect(config.argv).toEqual(["node", "script.js"]);
+  expect(config.runtime).toBe("node");
+});


### PR DESCRIPTION
This PR adds a new `getRuntimeConfig` function, which uses globalThis by default, and also allows for passing in a mocked globalThis object.

It returns the env runtime config, based on some things it detects.